### PR TITLE
blinky - Use console/stub instead of console/full.

### DIFF
--- a/apps/blinky/pkg.yml
+++ b/apps/blinky/pkg.yml
@@ -27,4 +27,4 @@ pkg.keywords:
 pkg.deps:
     - "@apache-mynewt-core/kernel/os"
     - "@apache-mynewt-core/hw/hal"
-    - "@apache-mynewt-core/sys/console/full"
+    - "@apache-mynewt-core/sys/console/stub"


### PR DESCRIPTION
Blinky doesn't use the console at all, so we can minimize the app further by using the stub console package.