### PR TITLE
Fix build with master

### DIFF
--- a/apps/blinky/pkg.yml
+++ b/apps/blinky/pkg.yml
@@ -28,3 +28,4 @@ pkg.deps:
     - "@apache-mynewt-core/kernel/os"
     - "@apache-mynewt-core/hw/hal"
     - "@apache-mynewt-core/sys/console/stub"
+    - "@apache-mynewt-core/sys/log/stub"


### PR DESCRIPTION
Error: Unsatisfied APIs detected:
    * log, required by: sys/log/modlog