### PR TITLE
fixed command at README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 Apache Blinky is a skeleton for new Apache Mynewt projects.  The user downloads
 this skeleton by issuing the "newt new" command (using Apache Newt).  Apache
-blinky also contains an example app and target for use with Apache Mynewt to
+Blinky also contains an example app and target for use with Apache Mynewt to
 help you get started.
 
 ## Building
@@ -42,7 +42,7 @@ You will need to download the Apache Newt tool, as documented in the [Getting St
 2. Download the Apache Mynewt Core package (executed from the blinky directory).
 
 ```no-highlight
-    $ newt install
+    $ newt upgrade
 ```
 
 3. Build the blinky app for the sim platform using the "my_blinky_sim" target


### PR DESCRIPTION
Running `newt install` show command not found:

```
newt install
Error: unknown command "install" for "newt"
Run 'newt --help' for usage.
```

Running `newt build my_blinky_sim` tells me to use `newt upgrade` to install dependencies.
```
newt build my_blinky_sim
Error: Repo "apache-mynewt-core" is not installed, please run `newt upgrade`!
```

Also capitalised blinky when preceded by Apache.