### PR TITLE
Add LED state print

### DIFF
--- a/apps/blinky/src/main.c
+++ b/apps/blinky/src/main.c
@@ -42,6 +42,7 @@ int
 mynewt_main(int argc, char **argv)
 {
     int rc;
+    bool led_state = true;
 
     sysinit();
 
@@ -56,6 +57,11 @@ mynewt_main(int argc, char **argv)
 
         /* Toggle the LED */
         hal_gpio_toggle(g_led_pin);
+        led_state = !led_state;
+
+        if (MYNEWT_VAL(BLINKY_PRINT_LED_STATE)) {
+            printf("LED state: %s\n", led_state ? "On" : "Off");
+        }
     }
     assert(0);
 

--- a/apps/blinky/syscfg.yml
+++ b/apps/blinky/syscfg.yml
@@ -20,9 +20,13 @@ syscfg.defs:
     LED_BLINK_PIN:
         description: Pin which blinks led.
         value: LED_BLINK_PIN
+    BLINKY_PRINT_LED_STATE:
+        description: Print led status.
+        value: 0
 
 syscfg.vals:
-    CONSOLE_IMPLEMENTATION: stub
     LOG_IMPLEMENTATION: stub
     STATS_IMPLEMENTATION: stub
+syscfg.vals.BLINKY_PRINT_LED_STATE:
+    CONSOLE_IMPLEMENTATION: full
 


### PR DESCRIPTION
This adds prints to console about LED status.
To enable prints set BLINKY_PRINT_LED_STATE to 1.