### PR TITLE
Use master branch for core repository

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -27,7 +27,7 @@ project.repositories:
 #
 repository.apache-mynewt-core:
     type: github
-    vers: 1.14.0
+    vers: 0.0.0
     user: apache
     repo: mynewt-core
 


### PR DESCRIPTION
This will be changed upon release, but newt from master downloads blinky master and thus all project should be from master branches